### PR TITLE
Library main should not point to raw source

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "update-in",
-  "version": "0.0.1-alpha.5",
+  "version": "0.0.1-alpha.6",
   "description": "Persistent functional object updates on vanilla js data structures (wraps react-addons-update)",
   "keywords": [
     "react",
@@ -19,7 +19,7 @@
     "build": "webpack",
     "dist": "webpack --config webpack.dist.js"
   },
-  "main": "./src/update-in.js",
+  "main": "./dist/update-in.js",
   "devDependencies": {
     "babel-core": "^5.8.22",
     "babel-loader": "^5.3.2",


### PR DESCRIPTION
For this library to be consumed by other libraries (e.g. react-cursor), its entry point must refer to code that is consumable without being run through babel/webpack. The code in /src cannot be directly imported because it has keywords like “import”.
